### PR TITLE
Add NuGet support

### DIFF
--- a/jQuery.Uniform.nuspec
+++ b/jQuery.Uniform.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <version>2.1.1</version>
+    <authors>Josh Pyles</authors>
+    <owners>Xavier Decoster</owners>
+    <licenseUrl>http://www.opensource.org/licenses/mit-license.php</licenseUrl>
+    <projectUrl>http://uniformjs.com/</projectUrl>
+    <dependencies>
+      <dependency id="jQuery" version="1.6" />
+    </dependencies>
+    <id>jQuery.Uniform</id>
+    <title />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Sexy form elements with jQuery. Now with HTML5 attributes! Make your form controls look how you want them to.</description>
+    <tags>jquery</tags>
+  </metadata>
+  <files>
+    <file src="jquery.uniform.js" target="content\Scripts"/>
+    <file src="jquery.uniform.min.js" target="content\Scripts"/>
+    <file src="themes\**" target="content\Content\Themes\uniformjs\"/>
+  </files>
+</package>


### PR DESCRIPTION
This pull request adds a NuGet manifest (.nuspec file) to the repository. It allows you to easily create a NuGet package and ship the project through NuGet.

You can do this automatically upon commit using [MyGet.org](http://www.myget.org) build services (free for OSS! contact us at info@myget.org). If you want I can set this up for you, just reply to this pull request for further details.

Main idea: continuously package the UniformJS sources in a NuGet package and have it on MyGet.org on your own feed so people can test it. With a click of a button you can then push the package from MyGet to NuGet (upstream package source) and release it to the masses. This very simple workflow is also [explained on our blog](http://blog.myget.org/post/2013/03/06/MyGet-Build-Services-Package-Versioning-Explained.aspx).

FYI: I currently already have a package [jQuery.Uniform on NuGet](http://nuget.org/packages/jQuery.Uniform), I'd happily transfer ownership to you.