### PR TITLE
explicitly pass in window so that module loader works in IE

### DIFF
--- a/jquery.uniform.js
+++ b/jquery.uniform.js
@@ -1065,4 +1065,4 @@ Enjoy!
             elementData.update($el, elementData.options);
         });
     };
-}(this, jQuery));
+}(window, jQuery));


### PR DESCRIPTION
So when I try to compile jquery.uniform w/ a dependency wrapper like Browserify/RequireJS, the generated script craps out in IE, specifically because jquery.uniform uses `wind.XMLHttpRequest` to check IE>7 & `wind` is set to `this` in the wrapper.

However, `this` context in a wrapper is `exports` object, not `window` for Browserify, thus failing the test. Therefore, setting `window` explicitly instead of `this` fixes it.